### PR TITLE
Avoid setting CLING_PROFILE forcedly when using distributed RDF

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -15,7 +15,7 @@ from DistRDF.Backends.Base import BaseBackend, distrdf_mapper, distrdf_reducer, 
 from DistRDF.Node import Node
 from DistRDF.Operation import Action, InstantAction, Operation
 from DistRDF.Backends import Utils
-from DistRDF.Profiling import profilable_mapper
+
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ class HeadNode(Node, ABC):
                 ComputationGraphGenerator.trigger_computation_graph, self._generate_graph_dict())
         
         if self._activate_profiling:
-
+            from DistRDF.Profiling import profilable_mapper
             mapper = self._visualization.decorate(profilable_mapper)
 
         else:


### PR DESCRIPTION
Instead, raise an error if a user is trying to use the `ClingProfile` feature without the variable being set.

This is done because setting the generation of jitted info from cling in a more programmatical way may lead to security/stability issues